### PR TITLE
Bugfix: describe_event_bus()['Policy'] should be JSON string, not object

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 
 from moto.core.exceptions import JsonRESTError
 from moto.core import BaseBackend, BaseModel
@@ -238,8 +239,10 @@ class EventsBackend(BaseBackend):
                 'Action': 'events:{0}'.format(data['action']),
                 'Resource': arn
             })
+        policy = {'Version': '2012-10-17', 'Statement': statements}
+        policy_json = json.dumps(policy)
         return {
-            'Policy': {'Version': '2012-10-17', 'Statement': statements},
+            'Policy': policy_json,
             'Name': 'default',
             'Arn': arn
         }

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -1,6 +1,7 @@
 import random
 
 import boto3
+import json
 
 from moto.events import mock_events
 from botocore.exceptions import ClientError
@@ -181,13 +182,15 @@ def test_permissions():
     client.put_permission(Action='PutEvents', Principal='222222222222', StatementId='Account2')
 
     resp = client.describe_event_bus()
-    assert len(resp['Policy']['Statement']) == 2
+    resp_policy = json.loads(resp['Policy'])
+    assert len(resp_policy['Statement']) == 2
 
     client.remove_permission(StatementId='Account2')
 
     resp = client.describe_event_bus()
-    assert len(resp['Policy']['Statement']) == 1
-    assert resp['Policy']['Statement'][0]['Sid'] == 'Account1'
+    resp_policy = json.loads(resp['Policy'])
+    assert len(resp_policy['Statement']) == 1
+    assert resp_policy['Statement'][0]['Sid'] == 'Account1'
 
 
 @mock_events


### PR DESCRIPTION
boto3.client('events')['Policy'] must be a string as per:

http://boto3.readthedocs.io/en/latest/reference/services/events.html#CloudWatchEvents.Client.describe_event_bus

Adding json.dumps() around the policy value ensures we do not return an unexpected dict

This change corrects an error when attempting to decode the policy:

json.load(boto3.client('events').describe_event_bus()['Policy'])