### PR TITLE
Bugfix: put_permission action parameter

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -210,7 +210,7 @@ class EventsBackend(BaseBackend):
         raise NotImplementedError()
 
     def put_permission(self, action, principal, statement_id):
-        if action is None or action != 'PutEvents':
+        if action is None or action != 'events:PutEvents':
             raise JsonRESTError('InvalidParameterValue', 'Action must be PutEvents')
 
         if principal is None or self.ACCOUNT_ID.match(principal) is None:

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -235,7 +235,7 @@ class EventsBackend(BaseBackend):
                 'Sid': statement_id,
                 'Effect': 'Allow',
                 'Principal': {'AWS': 'arn:aws:iam::{0}:root'.format(data['principal'])},
-                'Action': 'events:{0}'.format(data['action']),
+                'Action': data['action'],
                 'Resource': arn
             })
         return {

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -177,8 +177,8 @@ def test_remove_targets():
 def test_permissions():
     client = boto3.client('events', 'eu-central-1')
 
-    client.put_permission(Action='PutEvents', Principal='111111111111', StatementId='Account1')
-    client.put_permission(Action='PutEvents', Principal='222222222222', StatementId='Account2')
+    client.put_permission(Action='events:PutEvents', Principal='111111111111', StatementId='Account1')
+    client.put_permission(Action='events:PutEvents', Principal='222222222222', StatementId='Account2')
 
     resp = client.describe_event_bus()
     assert len(resp['Policy']['Statement']) == 2


### PR DESCRIPTION
Boto3/AWS requires that the Action parameter of put_permissions is fully qualified as "events:PutEvents" not "PutEvents"